### PR TITLE
Add array has deep key constraint

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Framework;
 
 use PHPUnit\Framework\Constraint\ArrayHasKey;
+use PHPUnit\Framework\Constraint\ArrayHasDeepKey;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\ClassHasAttribute;
 use PHPUnit\Framework\Constraint\ClassHasStaticAttribute;
@@ -92,6 +93,37 @@ abstract class Assert
         }
 
         $constraint = new ArrayHasKey($key);
+
+        static::assertThat($array, $constraint, $message);
+    }
+
+     /**
+     * Asserts that an array has a specified key in deep.
+     *
+     * @param int|string         $key
+     * @param array|\ArrayAccess $array
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     */
+    public static function assertArrayHasDeepKey($key, $array, string $message = ''): void
+    {
+        if (!(\is_int($key) || \is_string($key))) {
+            throw InvalidArgumentException::create(
+                1,
+                'integer or string'
+            );
+        }
+
+        if (!(\is_array($array) || $array instanceof \ArrayAccess)) {
+            throw InvalidArgumentException::create(
+                2,
+                'array or ArrayAccess'
+            );
+        }
+
+        $constraint = new ArrayHasDeepKey($key);
 
         static::assertThat($array, $constraint, $message);
     }
@@ -2479,6 +2511,11 @@ abstract class Assert
     public static function arrayHasKey($key): ArrayHasKey
     {
         return new ArrayHasKey($key);
+    }
+    
+    public static function arrayHasDeepKey($key): ArrayHasDeepKey
+    {
+        return new ArrayHasDeepKey($key);
     }
 
     public static function equalTo($value): IsEqual

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -9,8 +9,8 @@
  */
 namespace PHPUnit\Framework;
 
-use PHPUnit\Framework\Constraint\ArrayHasKey;
 use PHPUnit\Framework\Constraint\ArrayHasDeepKey;
+use PHPUnit\Framework\Constraint\ArrayHasKey;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\ClassHasAttribute;
 use PHPUnit\Framework\Constraint\ClassHasStaticAttribute;
@@ -97,7 +97,7 @@ abstract class Assert
         static::assertThat($array, $constraint, $message);
     }
 
-     /**
+    /**
      * Asserts that an array has a specified key in deep.
      *
      * @param int|string         $key
@@ -2512,7 +2512,7 @@ abstract class Assert
     {
         return new ArrayHasKey($key);
     }
-    
+
     public static function arrayHasDeepKey($key): ArrayHasDeepKey
     {
         return new ArrayHasDeepKey($key);

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -9,8 +9,8 @@
  */
 namespace PHPUnit\Framework;
 
-use PHPUnit\Framework\Constraint\ArrayHasKey;
 use PHPUnit\Framework\Constraint\ArrayHasDeepKey;
+use PHPUnit\Framework\Constraint\ArrayHasKey;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\ClassHasAttribute;
 use PHPUnit\Framework\Constraint\ClassHasStaticAttribute;

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Framework;
 
 use PHPUnit\Framework\Constraint\ArrayHasKey;
+use PHPUnit\Framework\Constraint\ArrayHasDeepKey;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\ClassHasAttribute;
 use PHPUnit\Framework\Constraint\ClassHasStaticAttribute;
@@ -79,6 +80,23 @@ use PHPUnit\Framework\MockObject\Stub\ReturnValueMap as ReturnValueMapStub;
 function assertArrayHasKey($key, $array, string $message = ''): void
 {
     Assert::assertArrayHasKey(...\func_get_args());
+}
+
+/**
+ * Asserts that an array has a specified key in deep.
+ *
+ * @param int|string         $key
+ * @param array|\ArrayAccess $array
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ * @throws Exception
+ *
+ * @see Assert::assertArrayHasDeepKey
+ */
+function assertArrayHasDeepKey($key, $array, string $message = ''): void
+{
+    Assert::assertArrayHasDeepKey(...\func_get_args());
 }
 
 /**
@@ -2065,6 +2083,11 @@ function containsOnlyInstancesOf(string $className): TraversableContainsOnly
 function arrayHasKey($key): ArrayHasKey
 {
     return Assert::arrayHasKey(...\func_get_args());
+}
+
+function arrayHasDeepKey($key): ArrayHasDeepKey
+{
+    return Assert::arrayHasDeepKey(...\func_get_args());
 }
 
 function equalTo($value): IsEqual

--- a/src/Framework/Constraint/ArrayHasDeepKey.php
+++ b/src/Framework/Constraint/ArrayHasDeepKey.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use ArrayAccess;
+
+/**
+ * Constraint that asserts that the array it is evaluated for has a given key in deep.
+ *
+ * Uses json_encode() to encode nested array and strpos() to check if the key is found in the input array, if
+ * not found the evaluation fails.
+ *
+ * The array key is passed in the constructor.
+ */
+final class ArrayHasDeepKey extends Constraint
+{
+    /**
+     * @var int|string
+     */
+    private $key;
+
+    /**
+     * @param int|string $key
+     */
+    public function __construct($key)
+    {
+        $this->key = $key;
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function toString(): string
+    {
+        return 'has the deep key ' . $this->exporter()->export($this->key);
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other value or object to evaluate
+     */
+    protected function matches($other): bool
+    {
+        if (\is_array($other)) {
+            return strpos(json_encode($other),"\"$this->key\":") ? true : false;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    protected function failureDescription($other): string
+    {
+        return 'an array ' . $this->toString();
+    }
+}

--- a/src/Framework/Constraint/ArrayHasDeepKey.php
+++ b/src/Framework/Constraint/ArrayHasDeepKey.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Framework\Constraint;
 
 use ArrayAccess;
+use ArrayObject;
 
 /**
  * Constraint that asserts that the array it is evaluated for has a given key in deep.
@@ -53,7 +54,13 @@ final class ArrayHasDeepKey extends Constraint
     protected function matches($other): bool
     {
         if (\is_array($other)) {
-            return strpos(json_encode($other),"\"$this->key\":") ? true : false;
+            return \strpos(\json_encode($other, \JSON_FORCE_OBJECT), "\"$this->key\":") ? true : false;
+        }
+
+        if ($other instanceof ArrayAccess) {
+            $other = new ArrayObject($other);
+
+            return \strpos(\json_encode($other->getArrayCopy(), \JSON_FORCE_OBJECT), "\"$this->key\":") ? true : false;
         }
 
         return false;

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -72,6 +72,29 @@ final class AssertTest extends TestCase
         $this->assertArrayHasKey(1, ['foo']);
     }
 
+    public function testAssertArrayHasDeepKeyThrowsExceptionForInvalidFirstArgument(): void
+    {
+        $this->expectException(Exception::class);
+
+        $this->assertArrayHasDeepKey(null, []);
+    }
+
+    public function testAssertArrayHasDeepKeyThrowsExceptionForInvalidSecondArgument(): void
+    {
+        $this->expectException(Exception::class);
+
+        $this->assertArrayHasDeepKey(0, null);
+    }
+
+    public function testAssertArrayHasDeepIntegerKey(): void
+    {
+        $this->assertArrayHasDeepKey(0, ['bar' => ['foo']]);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayHasDeepKey(1, ['bar' => ['foo']]);
+    }
+
     public function testAssertArrayNotHasKeyThrowsExceptionForInvalidFirstArgument(): void
     {
         $this->expectException(Exception::class);
@@ -102,6 +125,15 @@ final class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
 
         $this->assertArrayHasKey('bar', ['foo' => 'bar']);
+    }
+
+    public function testAssertArrayHasStringDeepKey(): void
+    {
+        $this->assertArrayHasDeepKey('foo', ['foo' => 'bar']);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayHasDeepKey('bar', ['foo' => 'bar']);
     }
 
     public function testAssertArrayNotHasStringKey(): void
@@ -147,6 +179,41 @@ final class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
 
         $this->assertArrayHasKey('foo', $array);
+    }
+
+    public function testAssertArrayHasDeepKeyAcceptsArrayObjectValue(): void
+    {
+        $array        = new \ArrayObject;
+        $array['bar'] = ['foo' => 'bar'];
+
+        $this->assertArrayHasDeepKey('foo', $array);
+    }
+
+    public function testAssertArrayHasDeepKeyProperlyFailsWithArrayObjectValue(): void
+    {
+        $array        = new \ArrayObject;
+        $array['bar'] = 'bar';
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayHasDeepKey('foo', $array);
+    }
+
+    public function testAssertArrayHasDeepKeyAcceptsArrayAccessValue(): void
+    {
+        $array        = new \SampleArrayAccess;
+        $array['bar'] = ['foo' => 'bar'];
+        $this->assertArrayHasDeepKey('foo', $array);
+    }
+
+    public function testAssertArrayHasDeepKeyProperlyFailsWithArrayAccessValue(): void
+    {
+        $array        = new \SampleArrayAccess;
+        $array['bar'] = 'bar';
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayHasDeepKey('foo', $array);
     }
 
     public function testAssertArrayNotHasKeyAcceptsArrayAccessValue(): void
@@ -1202,6 +1269,11 @@ XML;
     public function testAssertThatArrayHasKey(): void
     {
         $this->assertThat(['foo' => 'bar'], $this->arrayHasKey('foo'));
+    }
+
+    public function testAssertThatArrayHasDeepKey(): void
+    {
+        $this->assertThat(['foo' => ['foo2' => 'bar']], $this->arrayHasDeepKey('foo2'));
     }
 
     public function testAssertThatClassHasAttribute(): void

--- a/tests/unit/Framework/Constraint/ArrayHasDeepKeyTest.php
+++ b/tests/unit/Framework/Constraint/ArrayHasDeepKeyTest.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestFailure;
+
+/**
+ * @small
+ */
+final class ArrayHasDeepKeyTest extends ConstraintTestCase
+{
+    public function testConstraintArrayHasDeepKey(): void
+    {
+        $constraint = new ArrayHasDeepKey(0);
+
+        $this->assertFalse($constraint->evaluate([], '', true));
+        $this->assertEquals('has the deep key 0', $constraint->toString());
+        $this->assertCount(1, $constraint);
+
+        try {
+            $constraint->evaluate([]);
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that an array has the deep key 0.
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testConstraintArrayHasDeepKey2(): void
+    {
+        $constraint = new ArrayHasDeepKey(0);
+
+        try {
+            $constraint->evaluate([], 'custom message');
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+custom message\nFailed asserting that an array has the deep key 0.
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testConstraintArrayHasDeepKey0(): void
+    {
+        $constraint = new ArrayHasDeepKey(0);
+
+        try {
+            $constraint->evaluate(0, '');
+        } catch (ExpectationFailedException  $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that an array has the deep key 0.
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Summary :
While I was Writing some tests, I've run through a test case where I wanted to stub a method that accepts a nested array as argument, and based on some of the deep arguments I wanted to return different results.

I've tried using **ArrayHasKey** constraint as show in the code samples below but figured out that **ArrayHasKey** doesn't perform a deep search in the passed nested array, and if the searched key exists deeply the assertion will be falsey.
 I've looked in the API if there's something like **ArrayHasDeepKey** or something like ChaiJS [**containsAllDeepKeys**  ](https://www.chaijs.com/api/assert/#method_containsalldeepkeys) ,but It wasn't there.

 I ended up using a workaround in my case, and I figured out It'd be nice to have something like that in PHPUnit so I decided to contribute with one.
### Code samples :
#### Actual Method Calls
```php
/**
* I wanted to retrun different result based on existence of 
* either deepKey1 or deepKey2 in the inner payload array
*/
$firstCall = $this->client->method(
            'simpleStringParam',
            [
            "payload" => [
            "deepKey1" => "Foo"
                            ]
            ]
        );
$secondCall = $this->client->method(
            'simpleStringParam',
            [
            "payload" => [
            "deepKey2" => "Bar"
                            ]
            ]
        );
```
#### Attempted Stubbing
```php
// Initialize the stub
$clientStub = $this->stub(Client::class);

/**
* Stub the method to return  deepKey1 existence based response 
* Returns false Since the Argument doesn't have deepkey1 key directly in its keys
*/
 $clientStub->method('method')
                   ->with("simpleStringParam", $this->arrayHasKey('deepKey1'))
                   ->willReturn($this->getDeepKeyOneBasedResponse());

/**
* Stub the method to return  deepKey2 existence based response
*  Returns false Since the Argument doesn't have deepkey2 key directly in its keys
*/
 $clientStub->method('method')
                   ->with("simpleStringParam", $this->arrayHasKey('deepKey2'))
                   ->willReturn($this->getDeepKeyTwoBasedResponse());

```
#### Issue
**ArrayHasKey** Constraint will perform _**array_has_key(haystack, needle)**_ function which search for the key existence in a high level without searching deeply if the haystack is a nested array.

#### Fix
It would be great to have a constraint that search deeply in the array argument, It'll be something like this : 
```php
/**
* Stub the method to return  deepKey1 existence based response
*  Returns true Since the Argument  have deepkey1 key  in the inner payload array keys
*/
 $clientStub->method('method')
                   ->with("simpleStringParam", $this->arrayHasDeepKey('deepKey1'))
                   ->willReturn($this->getDeepKeyOneBasedResponse());

// Stub the method to return  deepKey2 existence based response
 $clientStub->method('method')
                   ->with("simpleStringParam", $this->arrayHasDeepKey('deepKey2'))
                   ->willReturn($this->getDeepKeyTwoBasedResponse());
```
